### PR TITLE
Morrison's product model should be MB200

### DIFF
--- a/products/cyanogen_morrison.mk
+++ b/products/cyanogen_morrison.mk
@@ -14,7 +14,7 @@ $(call inherit-product, vendor/cyanogen/products/gsm.mk)
 PRODUCT_NAME := cyanogen_morrison
 PRODUCT_BRAND := motorola
 PRODUCT_DEVICE := morrison
-PRODUCT_MODEL := CLIQ
+PRODUCT_MODEL := MB200
 PRODUCT_MANUFACTURER := Motorola
 
 #


### PR DESCRIPTION
The correct phone's model of the Morrison is MB200 (at it appears in stock roms actually).
"Cliq" is the name of the Morrison at T-Mobile and other carriers sell it as "Dext".
