### PR TITLE
Zeppelin's ro.product.model should be MB501

### DIFF
--- a/products/cyanogen_zeppelin.mk
+++ b/products/cyanogen_zeppelin.mk
@@ -14,7 +14,7 @@ $(call inherit-product, vendor/cyanogen/products/gsm.mk)
 PRODUCT_NAME := cyanogen_zeppelin
 PRODUCT_BRAND := motorola
 PRODUCT_DEVICE := zeppelin
-PRODUCT_MODEL := CLIQ XT
+PRODUCT_MODEL := MB501
 PRODUCT_MANUFACTURER := Motorola
 
 #


### PR DESCRIPTION
Cliq XT is T-Mobile comercial name of the MB501. On other carriers it's called Quench. The model is MB501 (and the board zeppelin)
